### PR TITLE
refa: avoid hard-coded uid in helm chart

### DIFF
--- a/charts/steadybit-extension-dynatrace/Chart.yaml
+++ b/charts/steadybit-extension-dynatrace/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-dynatrace
 description: Steadybit Dynatrace extension Helm chart for Kubernetes.
-version: 1.1.5
+version: 1.1.6
 appVersion: v1.0.6
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-extension-dynatrace/templates/deployment.yaml
+++ b/charts/steadybit-extension-dynatrace/templates/deployment.yaml
@@ -88,15 +88,10 @@ spec:
             httpGet:
               path: /health/readiness
               port: 8091
+          {{- with .Values.containerSecurityContext }}
           securityContext:
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 10000
-            runAsGroup: 10000
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         {{- include "extensionlib.deployment.volumes" (list .) | nindent 8 }}
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/steadybit-extension-dynatrace/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/steadybit-extension-dynatrace/tests/__snapshot__/deployment_test.yaml.snap
@@ -77,10 +77,11 @@ manifest should match snapshot using podAnnotations and Labels:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts: null
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-dynatrace
           volumes: null
 manifest should match snapshot with TLS:
@@ -164,13 +165,14 @@ manifest should match snapshot with TLS:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts:
                 - mountPath: /etc/extension/certificates/server-cert
                   name: certificate-server-cert
                   readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-dynatrace
           volumes:
             - name: certificate-server-cert
@@ -261,10 +263,11 @@ manifest should match snapshot with extra env vars:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts: null
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-dynatrace
           volumes: null
 manifest should match snapshot with extra labels:
@@ -346,10 +349,11 @@ manifest should match snapshot with extra labels:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts: null
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-dynatrace
           volumes: null
 manifest should match snapshot with mutual TLS:
@@ -435,9 +439,6 @@ manifest should match snapshot with mutual TLS:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts:
                 - mountPath: /etc/extension/certificates/client-cert-a
                   name: certificate-client-cert-a
@@ -445,6 +446,10 @@ manifest should match snapshot with mutual TLS:
                 - mountPath: /etc/extension/certificates/server-cert
                   name: certificate-server-cert
                   readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-dynatrace
           volumes:
             - name: certificate-client-cert-a
@@ -538,10 +543,11 @@ manifest should match snapshot with mutual TLS using containerPaths:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts: null
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-dynatrace
           volumes: null
 manifest should match snapshot with podSecurityContext:
@@ -621,12 +627,12 @@ manifest should match snapshot with podSecurityContext:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts: null
           securityContext:
+            runAsNonRoot: true
             runAsUser: 2222
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-dynatrace
           volumes: null
 manifest should match snapshot with priority class:
@@ -706,11 +712,12 @@ manifest should match snapshot with priority class:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts: null
           priorityClassName: my-priority-class
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-dynatrace
           volumes: null
 manifest should match snapshot without TLS:
@@ -790,9 +797,10 @@ manifest should match snapshot without TLS:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts: null
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-dynatrace
           volumes: null

--- a/charts/steadybit-extension-dynatrace/values.yaml
+++ b/charts/steadybit-extension-dynatrace/values.yaml
@@ -107,7 +107,18 @@ affinity: {}
 priorityClassName: null
 
 # podSecurityContext -- SecurityContext to apply to the pod.
-podSecurityContext: {}
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+  runAsNonRoot: true
+
+# containerSecurityContext -- SecurityContext to apply to the container.
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 
 # extraEnv -- Array with extra environment variables to add to the container
 # e.g:


### PR DESCRIPTION
In order to improve installation on openshift, we need to avoid the hard-coded uid/gid in the helm chart