### PR TITLE
chore: add Claude Code workflows

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,9 @@
+name: Claude Code Review
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, ready_for_review, reopened]
+jobs:
+  claude-review:
+    uses: steadybit/extension-kit/.github/workflows/reusable-claude-pr-review.yml@main
+    secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,14 @@
+name: Claude Code
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+jobs:
+  claude:
+    uses: steadybit/extension-kit/.github/workflows/reusable-claude-comments.yml@main
+    secrets: inherit


### PR DESCRIPTION
Wires up the two reusable Claude Code workflows from extension-kit:
- `claude.yml` — responds to @claude mentions in issues, PR comments, and reviews
- `claude-review.yml` — automatically reviews every PR opened against main

Both delegate to the centrally maintained reusable workflows in steadybit/extension-kit.