### PR TITLE
fix: escape entitySelector in Dynatrace problems query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: URL-escape the `entitySelector` when querying Dynatrace problems, preventing query-parameter injection into the Dynatrace API (matches the existing escaping in the entities query)
+
 ## v1.0.24
 
 - build(deps): bump github.com/steadybit/extension-kit

--- a/config/config.go
+++ b/config/config.go
@@ -138,12 +138,12 @@ func (s *Specification) DeleteMaintenanceWindow(_ context.Context, maintenanceWi
 }
 
 func (s *Specification) GetProblems(_ context.Context, from time.Time, entitySelector *string) ([]types.Problem, *http.Response, error) {
-	url := fmt.Sprintf("%s/v2/problems?problemSelector=status(\"OPEN\")&pageSize=500", s.ApiBaseUrl)
+	requestUrl := fmt.Sprintf("%s/v2/problems?problemSelector=status(\"OPEN\")&pageSize=500", s.ApiBaseUrl)
 	if entitySelector != nil {
-		url = fmt.Sprintf("%s&entitySelector=%s", url, *entitySelector)
+		requestUrl = fmt.Sprintf("%s&entitySelector=%s", requestUrl, url.QueryEscape(*entitySelector))
 	}
 
-	responseBody, response, err := s.do(url, "GET", nil)
+	responseBody, response, err := s.do(requestUrl, "GET", nil)
 	if err != nil {
 		return nil, response, err
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -307,3 +307,28 @@ func Test_GetProblems_Success(t *testing.T) {
 		t.Fatalf("bad problems: %+v", problems)
 	}
 }
+
+func Test_GetProblems_EscapesEntitySelector(t *testing.T) {
+	rc := &reqCapture{}
+	srv := newMockHTTPServer(t, rc)
+	defer srv.Close()
+
+	spec := Specification{ApiBaseUrl: srv.URL, ApiToken: "X"}
+	// A selector containing characters that would otherwise break out of the query parameter.
+	sel := `type("HOST"),tag("a&b=c")`
+	if _, _, err := spec.GetProblems(context.Background(), time.Now(), &sel); err != nil {
+		t.Fatalf("GetProblems err: %v", err)
+	}
+
+	// Properly escaped, the value round-trips through query parsing unchanged...
+	if got := rc.Query.Get("entitySelector"); got != sel {
+		t.Fatalf("entitySelector not escaped: got %q want %q", got, sel)
+	}
+	// ...and the embedded '&b=c' did not inject a separate parameter or corrupt problemSelector.
+	if ps := rc.Query.Get("problemSelector"); ps != `status("OPEN")` {
+		t.Fatalf("problemSelector corrupted: %q", ps)
+	}
+	if rc.Query.Get("b") != "" {
+		t.Fatalf("injected parameter leaked into query: b=%q", rc.Query.Get("b"))
+	}
+}


### PR DESCRIPTION
## Problem (MAJOR — query-parameter injection)

`GetProblems` built the request URL by interpolating `*entitySelector` **raw** into the query string:

```go
url = fmt.Sprintf("%s&entitySelector=%s", url, *entitySelector)
```

The sibling `GetEntities` already escapes its selector with `url.QueryEscape`. An `entitySelector` containing `&`, `#`, spaces, etc. could break out of the parameter and inject additional query parameters into the authenticated Dynatrace API request (e.g. override `pageSize`/`problemSelector`), or malform the request.

(The omission was likely caused by the local variable being named `url`, which shadowed the `net/url` package and prevented calling `url.QueryEscape`.)

## Fix

- Rename the shadowing local `url` → `requestUrl`.
- Wrap the selector with `url.QueryEscape(*entitySelector)`, matching `GetEntities`.

Query structure is unchanged for normal selectors.

## Testing
- `go build ./...`, `go vet`, `gofmt` clean.
- Added `Test_GetProblems_EscapesEntitySelector`: a selector containing `&b=c` round-trips through query parsing unchanged, `problemSelector` is not corrupted, and no injected `b` parameter leaks.
- `go test ./config/` passes.

## /simplify
4-agent pass: all clean — escaping per-call matches the established `GetEntities` pattern (right altitude); no other query parameter is left unescaped. The altitude agent noted two optional, out-of-scope follow-ups: a `url.Values`-based construction across all methods, and `url.PathEscape` on the server-generated `maintenanceWindowId` path segment.