### PR TITLE
feat(problem check): add fail early option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add a "Fail early" option to the problem check. When enabled (the default, matching the previous behavior), the check fails as soon as the condition is violated. When disabled, the check keeps collecting events for the whole duration and only fails at the end of the step.
 - fix: URL-escape the `entitySelector` when querying Dynatrace problems, preventing query-parameter injection into the Dynatrace API (matches the existing escaping in the entities query)
 
 ## v1.0.24

--- a/extproblems/problem_check.go
+++ b/extproblems/problem_check.go
@@ -258,7 +258,7 @@ func ProblemCheckStatus(ctx context.Context, state *ProblemCheckState, api Probl
 		if completed && !state.ConditionCheckSuccess {
 			if state.Condition == conditionNoProblems {
 				checkError = new(action_kit_api.ActionKitError{
-					Title:  "No problem expected, but problems found.",
+					Title:  "Expected the problems to clear at least once, but problems were present for the entire step.",
 					Status: extutil.Ptr(action_kit_api.Failed),
 				})
 			} else if state.Condition == conditionAtLeastOneProblem {

--- a/extproblems/problem_check.go
+++ b/extproblems/problem_check.go
@@ -34,6 +34,11 @@ type ProblemCheckState struct {
 	Condition             string
 	ConditionCheckMode    string
 	ConditionCheckSuccess bool
+	FailEarly             bool
+	// DeviationSeen and DeviationTitle are used in 'fail at end' mode (FailEarly = false) to remember
+	// that the condition was violated during the step so the failure can be reported once the step ends.
+	DeviationSeen  bool
+	DeviationTitle string
 }
 
 func NewProblemCheckAction() action_kit_sdk.Action[ProblemCheckState] {
@@ -115,6 +120,16 @@ func (m *ProblemCheckAction) Describe() action_kit_api.ActionDescription {
 				Required: new(true),
 				Order:    new(4),
 			},
+			{
+				Name:         "failEarly",
+				Label:        "Fail early",
+				Description:  new("If enabled, the check fails as soon as the condition is violated. If disabled, the check keeps collecting events for the whole duration and only fails at the end of the step. Only affects the 'All the time' mode; 'At least once' can only be evaluated at the end of the step."),
+				Type:         action_kit_api.ActionParameterTypeBoolean,
+				DefaultValue: new("true"),
+				Advanced:     new(true),
+				Required:     new(false),
+				Order:        new(5),
+			},
 		},
 		Widgets: new([]action_kit_api.Widget{
 			action_kit_api.StateOverTimeWidget{
@@ -165,6 +180,12 @@ func (m *ProblemCheckAction) Prepare(_ context.Context, state *ProblemCheckState
 		state.ConditionCheckMode = fmt.Sprintf("%v", request.Config["conditionCheckMode"])
 	}
 
+	// Default to failing early to preserve the previous behavior for experiments that don't set this parameter.
+	state.FailEarly = true
+	if request.Config["failEarly"] != nil {
+		state.FailEarly = extutil.ToBool(request.Config["failEarly"])
+	}
+
 	return nil, nil
 }
 
@@ -200,15 +221,29 @@ func ProblemCheckStatus(ctx context.Context, state *ProblemCheckState, api Probl
 	completed := now.After(state.End)
 	var checkError *action_kit_api.ActionKitError
 	if state.ConditionCheckMode == conditionCheckModeAllTheTime {
+		var deviationTitle string
 		if state.Condition == conditionNoProblems && len(problems) > 0 {
-			checkError = new(action_kit_api.ActionKitError{
-				Title:  fmt.Sprintf("No problem expected, but %d problems found.", len(problems)),
-				Status: extutil.Ptr(action_kit_api.Failed),
-			})
+			deviationTitle = fmt.Sprintf("No problem expected, but %d problems found.", len(problems))
 		}
 		if state.Condition == conditionAtLeastOneProblem && len(problems) == 0 {
+			deviationTitle = "At least one problem expected, but no problems found."
+		}
+		if deviationTitle != "" {
+			if state.FailEarly {
+				// Fail as soon as the condition is violated.
+				checkError = new(action_kit_api.ActionKitError{
+					Title:  deviationTitle,
+					Status: extutil.Ptr(action_kit_api.Failed),
+				})
+			} else {
+				// Keep collecting events and remember the deviation to report it at the end of the step.
+				state.DeviationSeen = true
+				state.DeviationTitle = deviationTitle
+			}
+		}
+		if !state.FailEarly && completed && state.DeviationSeen {
 			checkError = new(action_kit_api.ActionKitError{
-				Title:  "At least one problem expected, but no problems found.",
+				Title:  state.DeviationTitle,
 				Status: extutil.Ptr(action_kit_api.Failed),
 			})
 		}

--- a/extproblems/problem_check_test.go
+++ b/extproblems/problem_check_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2022 Steadybit GmbH
+
+package extproblems
+
+import (
+	"context"
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/extension-dynatrace/types"
+	"github.com/steadybit/extension-kit/extutil"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"testing"
+	"time"
+)
+
+type problemsApiMock struct {
+	mock.Mock
+}
+
+func (m *problemsApiMock) GetProblems(ctx context.Context, from time.Time, entitySelector *string) ([]types.Problem, *http.Response, error) {
+	args := m.Called(ctx, from, entitySelector)
+	return args.Get(0).([]types.Problem), args.Get(1).(*http.Response), args.Error(2)
+}
+
+func TestPrepareDefaultsFailEarlyToTrue(t *testing.T) {
+	// Given
+	request := extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
+		Config: map[string]interface{}{
+			"duration":           1000 * 60,
+			"condition":          conditionNoProblems,
+			"conditionCheckMode": conditionCheckModeAllTheTime,
+		},
+	})
+	action := ProblemCheckAction{}
+	state := action.NewEmptyState()
+
+	// When
+	result, err := action.Prepare(context.TODO(), &state, request)
+
+	// Then
+	require.Nil(t, result)
+	require.Nil(t, err)
+	require.True(t, state.FailEarly) // defaults to true when not provided (non-breaking for old experiments)
+}
+
+func TestPrepareExtractsFailEarlyFalse(t *testing.T) {
+	// Given
+	request := extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
+		Config: map[string]interface{}{
+			"duration":           1000 * 60,
+			"condition":          conditionNoProblems,
+			"conditionCheckMode": conditionCheckModeAllTheTime,
+			"failEarly":          false,
+		},
+	})
+	action := ProblemCheckAction{}
+	state := action.NewEmptyState()
+
+	// When
+	result, err := action.Prepare(context.TODO(), &state, request)
+
+	// Then
+	require.Nil(t, result)
+	require.Nil(t, err)
+	require.False(t, state.FailEarly)
+}
+
+func TestAllTheTimeFailEarly(t *testing.T) {
+	// Given - a problem exists while "No problem expected", time not yet up
+	mockedApi := new(problemsApiMock)
+	mockedApi.On("GetProblems", mock.Anything, mock.Anything, mock.Anything).Return([]types.Problem{{}}, extutil.Ptr(http.Response{StatusCode: 200}), nil)
+
+	action := ProblemCheckAction{}
+	state := action.NewEmptyState()
+	state.Start = time.Now()
+	state.End = time.Now().Add(time.Minute * 1) // time not yet up
+	state.Condition = conditionNoProblems
+	state.ConditionCheckMode = conditionCheckModeAllTheTime
+	state.FailEarly = true
+
+	// When
+	result, err := ProblemCheckStatus(context.Background(), &state, mockedApi)
+
+	// Then - fails immediately
+	require.Nil(t, err)
+	require.False(t, result.Completed)
+	require.NotNil(t, result.Error)
+	require.Equal(t, "No problem expected, but 1 problems found.", result.Error.Title)
+}
+
+func TestAllTheTimeFailAtEnd(t *testing.T) {
+	// First call: deviation but time not up -> no error, deviation remembered
+	mockedApi := new(problemsApiMock)
+	mockedApi.On("GetProblems", mock.Anything, mock.Anything, mock.Anything).Return([]types.Problem{{}}, extutil.Ptr(http.Response{StatusCode: 200}), nil).Once()
+
+	action := ProblemCheckAction{}
+	state := action.NewEmptyState()
+	state.Start = time.Now()
+	state.End = time.Now().Add(time.Minute * 1) // time not yet up
+	state.Condition = conditionNoProblems
+	state.ConditionCheckMode = conditionCheckModeAllTheTime
+	state.FailEarly = false
+
+	result, err := ProblemCheckStatus(context.Background(), &state, mockedApi)
+	require.Nil(t, err)
+	require.False(t, result.Completed)
+	require.Nil(t, result.Error) // does not fail early
+	require.True(t, state.DeviationSeen)
+
+	// Second call: problems gone but time is up and a deviation was seen -> fails at the end
+	mockedApi.On("GetProblems", mock.Anything, mock.Anything, mock.Anything).Return([]types.Problem{}, extutil.Ptr(http.Response{StatusCode: 200}), nil).Once()
+	state.End = time.Now().Add(time.Minute * -1) // time is up
+
+	result, err = ProblemCheckStatus(context.Background(), &state, mockedApi)
+	require.Nil(t, err)
+	require.True(t, result.Completed)
+	require.NotNil(t, result.Error)
+	require.Equal(t, "No problem expected, but 1 problems found.", result.Error.Title)
+}
+
+func TestAllTheTimeFailAtEndSucceedsWhenNeverDeviated(t *testing.T) {
+	// Given - no problems throughout while "No problem expected", time is up
+	mockedApi := new(problemsApiMock)
+	mockedApi.On("GetProblems", mock.Anything, mock.Anything, mock.Anything).Return([]types.Problem{}, extutil.Ptr(http.Response{StatusCode: 200}), nil)
+
+	action := ProblemCheckAction{}
+	state := action.NewEmptyState()
+	state.Start = time.Now()
+	state.End = time.Now().Add(time.Minute * -1) // time is up
+	state.Condition = conditionNoProblems
+	state.ConditionCheckMode = conditionCheckModeAllTheTime
+	state.FailEarly = false
+
+	// When
+	result, err := ProblemCheckStatus(context.Background(), &state, mockedApi)
+
+	// Then
+	require.Nil(t, err)
+	require.True(t, result.Completed)
+	require.Nil(t, result.Error)
+	require.False(t, state.DeviationSeen)
+}


### PR DESCRIPTION
## Problem

The ending time of our checks isn't consistently applied, which makes experiments hard to time. A check can fail early (on the first deviating event) or only at the end of the step, with no way to choose. This adds a per-check option, following the reference implementation in `extension-datadog`.

## Change

Adds a **`failEarly` boolean** to the Dynatrace problem check:

- **Enabled (default)** — the check fails as soon as the condition is violated (today's `All the time` behavior).
- **Disabled** — the check keeps collecting events for the whole step duration and only fails at the end.

Details:
- Parameter lives in the **Advanced** section, is **optional**, and defaults to `true` both in its description and in `Prepare` (when the key is absent), so **existing experiments are non-breaking**.
- Fail-at-end is implemented by remembering the deviation in state (`DeviationSeen`/`DeviationTitle`) and only emitting the error once the step completes.
- Only affects `All the time` mode. `At least once` can only be evaluated at the end of the step, so the option is a no-op there (documented in the parameter description).

The parameter description is what the Hub renders, satisfying the "documented in the Hub" acceptance criterion.

## Note

Unlike the Datadog check, this check's conditions are based on `len(problems)`, which is always determinate, so the "unknown/no-data silently passes" bug fixed in datadog#216 does **not** apply here.

## Tests

- Added `extproblems/problem_check_test.go` (none existed): default/explicit `failEarly` extraction, fail-early, fail-at-end (deviation then end), and fail-at-end success when never deviated.
- 5/5 tests pass, `go vet` clean.