### PR TITLE
fix(problem check): use past tense for fail-at-end message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add a "Fail early" option to the problem check. When enabled (the default, matching the previous behavior), the check fails as soon as the condition is violated. When disabled, the check keeps collecting events for the whole duration and only fails at the end of the step.
+- Add a "Fail early" option to the problem check. When enabled (the default, matching the previous behavior), the check fails as soon as the condition is violated. When disabled, the check keeps collecting events for the whole duration and only fails at the end of the step. When failing at the end, the message uses past tense ("were found during the step") since the condition may have recovered by then.
 - fix: URL-escape the `entitySelector` when querying Dynatrace problems, preventing query-parameter injection into the Dynatrace API (matches the existing escaping in the entities query)
 
 ## v1.0.24

--- a/extproblems/problem_check.go
+++ b/extproblems/problem_check.go
@@ -221,12 +221,17 @@ func ProblemCheckStatus(ctx context.Context, state *ProblemCheckState, api Probl
 	completed := now.After(state.End)
 	var checkError *action_kit_api.ActionKitError
 	if state.ConditionCheckMode == conditionCheckModeAllTheTime {
-		var deviationTitle string
+		// deviationTitle is the present-tense message for the fail-early case; deferredTitle is the
+		// past-tense message reported at the end of the step, since the condition may have recovered
+		// by then.
+		var deviationTitle, deferredTitle string
 		if state.Condition == conditionNoProblems && len(problems) > 0 {
 			deviationTitle = fmt.Sprintf("No problem expected, but %d problems found.", len(problems))
+			deferredTitle = fmt.Sprintf("No problem expected, but %d problems were found during the step.", len(problems))
 		}
 		if state.Condition == conditionAtLeastOneProblem && len(problems) == 0 {
 			deviationTitle = "At least one problem expected, but no problems found."
+			deferredTitle = "At least one problem expected, but no problems were found during the step."
 		}
 		if deviationTitle != "" {
 			if state.FailEarly {
@@ -238,7 +243,7 @@ func ProblemCheckStatus(ctx context.Context, state *ProblemCheckState, api Probl
 			} else {
 				// Keep collecting events and remember the deviation to report it at the end of the step.
 				state.DeviationSeen = true
-				state.DeviationTitle = deviationTitle
+				state.DeviationTitle = deferredTitle
 			}
 		}
 		if !state.FailEarly && completed && state.DeviationSeen {

--- a/extproblems/problem_check_test.go
+++ b/extproblems/problem_check_test.go
@@ -117,7 +117,7 @@ func TestAllTheTimeFailAtEnd(t *testing.T) {
 	require.Nil(t, err)
 	require.True(t, result.Completed)
 	require.NotNil(t, result.Error)
-	require.Equal(t, "No problem expected, but 1 problems found.", result.Error.Title)
+	require.Equal(t, "No problem expected, but 1 problems were found during the step.", result.Error.Title) // past tense at end of step
 }
 
 func TestAllTheTimeFailAtEndSucceedsWhenNeverDeviated(t *testing.T) {


### PR DESCRIPTION
## Context

Follow-up to the "Fail early" option (#137). A reviewer flagged that the **fail-at-end** failure message was frozen in present tense; if the condition recovers before the step ends, the end-of-step error can mislead operators.

## Change

- **Fail early** (default): unchanged present-tense message (e.g. `No problem expected, but 3 problems found.`).
- **Fail at end** (Fail early disabled): past-tense message (e.g. `No problem expected, but 3 problems were found during the step.`).

No behavior change; message wording only. Consistent with the same fix in `extension-datadog` and `extension-grafana`.

## Tests

- Updated `TestAllTheTimeFailAtEnd` to assert the past-tense message; the fail-early test keeps the present tense.
- All `extproblems` tests pass, `go vet` clean.